### PR TITLE
Add include for temporary notices.

### DIFF
--- a/_includes/notice.html
+++ b/_includes/notice.html
@@ -1,0 +1,6 @@
+{% if false %}
+        <div class="message--unsure l--pad-all-quarter">
+          <span class="badge--unsure l--push-h-1">!</span>
+          Warning notice goes here.
+        </div>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,6 +38,8 @@
             <a href="http://translate.zanata.org" class="button--primary button--full">Go to the app</a>
           </div>
         </div>
+        {% include notice.html %}
+
       </header>
 
       {{ content }}


### PR DESCRIPTION
An example notice is shown in _includes/notice.html, which can be shown
by changing {% if false %} to {% if true %}.

Multiple notices can be added, and time-dependent notices could be added using different conditions for the if block.
